### PR TITLE
Replace `NVIM_TUI_ENABLE_TRUE_COLOR` in favor of `set termguicolors`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ Add this stuff to your `.nvimrc` (or wherever the kids are putting it these days
 
 - TrueColor must be turned on:
   - Neovim 0.1.5 or greater, `set termguicolors` in your nvim config
-  - Neovim < 0.1.5, `let $NVIM_TUI_ENABLE_TRUE_COLOR=1`
+  - Neovim < 0.1.5, `let $NVIM_TUI_ENABLE_TRUE_COLOR=1` in your nvim config
 - If you want italic props, https://alexpearce.me/2014/05/italics-in-iterm2-vim-tmux/
 - You'll want to install https://github.com/pangloss/vim-javascript and https://github.com/mxw/vim-jsx

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ Add this stuff to your `.nvimrc` (or wherever the kids are putting it these days
 
 - TrueColor must be turned on:
   - Neovim 0.1.5 or greater, `set termguicolors` in your nvim config
-  - Neovim < 0.1.5, `let $NVIM_TUI_ENABLE_TRUE_COLOR=1` in your nvim config
+  - Neovim < 0.1.5, `let $NVIM_TUI_ENABLE_TRUE_COLOR=1` in your nvim config (or as an env var in your zshrc)
 - If you want italic props, https://alexpearce.me/2014/05/italics-in-iterm2-vim-tmux/
 - You'll want to install https://github.com/pangloss/vim-javascript and https://github.com/mxw/vim-jsx

--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ Add this stuff to your `.nvimrc` (or wherever the kids are putting it these days
 ## Prerequisites
 
 - TrueColor must be turned on
-  - Do this by setting the `NVIM_TUI_ENABLE_TRUE_COLOR=1` env var
+  - Do this by setting `set termguicolors` in your nvim config
 - If you want italic props, https://alexpearce.me/2014/05/italics-in-iterm2-vim-tmux/
 - You'll want to install https://github.com/pangloss/vim-javascript and https://github.com/mxw/vim-jsx

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Add this stuff to your `.nvimrc` (or wherever the kids are putting it these days
 
 ## Prerequisites
 
-- TrueColor must be turned on
-  - Do this by setting `set termguicolors` in your nvim config
+- TrueColor must be turned on:
+  - Neovim 0.1.5 or greater, `set termguicolors` in your nvim config
+  - Neovim < 0.1.5, `let $NVIM_TUI_ENABLE_TRUE_COLOR=1`
 - If you want italic props, https://alexpearce.me/2014/05/italics-in-iterm2-vim-tmux/
 - You'll want to install https://github.com/pangloss/vim-javascript and https://github.com/mxw/vim-jsx


### PR DESCRIPTION
For neovim version > 0.1.5
https://github.com/neovim/neovim/wiki/Following-HEAD#20160511